### PR TITLE
Fix sound path default and use start line offset

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -80,7 +80,7 @@ class SkatingControlPanel(QWidget):
             "goSound": getattr(self, "go_sound", "Sounds/goSound.mp3"),
             "readySound": getattr(self, "ready_sound", "Sounds/readySound.mp3"),
             "falseStartSound": getattr(self, "false_start_sound", "Sounds/falseStartBuzzer.mp3"),
-            "gunSound": getattr(self, "gun_sound", "gunSound.mp3")
+            "gunSound": getattr(self, "gun_sound", "Sounds/gunSound.mp3")
         }
 
         with open("config.json", "w") as f:

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def isReady(frame):
     hips_y = get_landmark_y_center(frame, [mp_pose.PoseLandmark.LEFT_HIP, mp_pose.PoseLandmark.RIGHT_HIP])
     if hips_y is None:
         return False
-    imaginary_line = START_LINE_Y - 50
+    imaginary_line = START_LINE_Y - IMAGINARY_START_LINE_OFFSET
     draw_lines(frame, imaginary_line, START_LINE_Y, "")
     return imaginary_line <= hips_y <= START_LINE_Y and not crossedLine(frame)
 
@@ -93,7 +93,7 @@ def main():
 
         isMovement(frame, landMarks, movements, MOVEMENT_THRESHOLD, fullBody=True)
         draw_lines(frame, PRE_START_Y_MIN, PRE_START_Y_MAX,state="done")
-        imaginary_line = START_LINE_Y - 50
+        imaginary_line = START_LINE_Y - IMAGINARY_START_LINE_OFFSET
         draw_lines(frame, imaginary_line, START_LINE_Y, "yayy")
         TpreStart, canGoToStartLine = preStartingLine(frame, TpreStart)
 


### PR DESCRIPTION
## Summary
- use the configured `IMAGINARY_START_LINE_OFFSET` constant in `main.py`
- correct the default gun sound path in `app_ui.py`

## Testing
- `python -m py_compile app_ui.py main.py movement.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6845bbd5ca608322a58cfe5434bf1e4d